### PR TITLE
Delete action depending on user Authorization and permission

### DIFF
--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -17,7 +17,8 @@ exports.signup = catchAsync( async(req, res) =>{
         email: req.body.email,
         password: req.body.password,
         confirmPassword: req.body.confirmPassword,
-        passwordChangedAt: req.body.passwordChangedAt
+        passwordChangedAt: req.body.passwordChangedAt,
+        role: req.body.role
     });
 
     //creating json web token
@@ -97,3 +98,17 @@ exports.protectedRoutes = catchAsync(async (req, res, next ) =>{
     req.user = freshUser;
     next();
 })
+
+//RESTRICTING ACCESS ACCORDING TO THE LEVEL
+exports.restrictTo = (...roles) =>{
+    return (req, res, next) =>{
+        //check if the req.user from above has roles such as [ 'admin' , 'lead-guide']
+        if(!roles.includes(req.user.role)){
+            return next( new AppError('You do not have permission to perform this action.', 401));
+        }
+
+        //if req.user.role has [admin or lead-guide ] then proceed to next() and perform action
+
+        next();
+    }
+}

--- a/models/userModel.js
+++ b/models/userModel.js
@@ -23,6 +23,11 @@ const userSchema = new mongoose.Schema({
     photo: {
         type: String
     },
+    role: {
+        type: String,
+        enum: ['user', 'guide', 'lead-guide', 'admin'],
+        default: 'user'
+    },
     password: {
         type: String,
         required: [true, 'Please provide password'],

--- a/routes/tourRoutes.js
+++ b/routes/tourRoutes.js
@@ -1,6 +1,6 @@
 const express = require('express');
 const { getAllTours, getTour, createTour, updateTours, deleteTour, topCheapTours, getTourStats, getMonthlyPlan } = require('./../controllers/tourControllers')
-const { protectedRoutes } = require('./../controllers/authController')
+const { protectedRoutes, restrictTo } = require('./../controllers/authController')
 
 const router = express.Router();
 
@@ -22,6 +22,6 @@ router.route('/')
 router.route('/:id')
     .get(getTour)
     .patch( updateTours)
-    .delete( deleteTour)
+    .delete(protectedRoutes, restrictTo('admin','lead-guide'), deleteTour)
 
 module.exports = router


### PR DESCRIPTION
In order to delete tour, we actually check if the user is logged in and has access flag of either admin or lead-guide. Before we run deleteTour middleware, we run protectedRoutes middleware, once varified with jwt, then we check access flag, if user has admin role, then deletion is allowed else 403 permission error will be shown. 